### PR TITLE
Fix camera becoming visible during back swipe from mood detail

### DIFF
--- a/Moody/Moody/RootViewController.swift
+++ b/Moody/Moody/RootViewController.swift
@@ -70,8 +70,15 @@ class RootViewController: UIViewController, ManagedObjectContextSettable, SegueH
 extension RootViewController: UINavigationControllerDelegate {
 
     func navigationController(navigationController: UINavigationController, willShowViewController viewController: UIViewController, animated: Bool) {
-        let cameraVisible = (viewController as? MoodDetailViewController) == nil
-        setCameraVisibility(cameraVisible)
+        if viewController is MoodDetailViewController {
+            setCameraVisibility(false)
+        }
+    }
+    
+    func navigationController(navigationController: UINavigationController, didShowViewController viewController: UIViewController, animated: Bool) {
+        if !(viewController is MoodDetailViewController) {
+            setCameraVisibility(true)
+        }
     }
 
 }


### PR DESCRIPTION
There's a minor issue when swiping back from the mood detail screen that causes the camera view to appear at the start of the swipe. If the swipe is cancelled, the camera view stays visible on the detail screen. Here's a screenshot of it mid-swipe.

![image](https://cloud.githubusercontent.com/assets/430436/12108340/871a1358-b32b-11e5-88b1-62b90cfef31b.png)

The fix here adds an implementation for `navigationController:didShowViewController:` which delays showing the camera until the transition is complete. `navigationController:willShowViewController` was updated to only hide the camera when moving to the detail screen.

This also fixes a navigation bar animation glitch when pushing a VC from RegionsTableViewController.

Thanks for the great book! :beer: 
