### PR TITLE
Fix warnings

### DIFF
--- a/Moody/Moody.xcodeproj/project.pbxproj
+++ b/Moody/Moody.xcodeproj/project.pbxproj
@@ -922,7 +922,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = objc.io;
 				TargetAttributes = {
 					174495471AFB62A0007C9A75 = {
@@ -1272,6 +1272,8 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};

--- a/Moody/Moody.xcodeproj/project.xcworkspace/xcshareddata/Moody.xcscmblueprint
+++ b/Moody/Moody.xcodeproj/project.xcworkspace/xcshareddata/Moody.xcscmblueprint
@@ -1,19 +1,21 @@
 {
-  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "BBA5EDA3CA72EFF0894661E3303EE217ACDFD395",
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "C94DEAC25159F8E0C374997002E08B259F2C330B",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
 
   },
   "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
     "3642B9C2595E4DBE94B8CE549AE37A84C04234BD" : 0,
+    "C94DEAC25159F8E0C374997002E08B259F2C330B" : 0,
     "BBA5EDA3CA72EFF0894661E3303EE217ACDFD395" : 0
   },
   "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "26DAE5A5-0AFB-416E-BD78-14266C11B28A",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
     "3642B9C2595E4DBE94B8CE549AE37A84C04234BD" : "core-data-bookMoody\/lib\/DominantColor",
+    "C94DEAC25159F8E0C374997002E08B259F2C330B" : "core-data\/",
     "BBA5EDA3CA72EFF0894661E3303EE217ACDFD395" : "core-data-book"
   },
   "DVTSourceControlWorkspaceBlueprintNameKey" : "Moody",
-  "DVTSourceControlWorkspaceBlueprintVersion" : 203,
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
   "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "Moody\/Moody.xcodeproj",
   "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
     {
@@ -25,6 +27,11 @@
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:objcio\/core-data-book.git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "BBA5EDA3CA72EFF0894661E3303EE217ACDFD395"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/combes\/core-data.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "C94DEAC25159F8E0C374997002E08B259F2C330B"
     }
   ]
 }

--- a/Moody/Moody.xcodeproj/xcshareddata/xcschemes/Moody.xcscheme
+++ b/Moody/Moody.xcodeproj/xcshareddata/xcschemes/Moody.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Moody/Moody/CameraViewController.swift
+++ b/Moody/Moody/CameraViewController.swift
@@ -26,7 +26,7 @@ class CameraViewController: UIViewController {
         super.viewDidLoad()
         session = CaptureSession(delegate: self)
         cameraView.setupForPreviewLayer(session.createPreviewLayer())
-        let recognizer = UITapGestureRecognizer(target: self, action: "snap:")
+        let recognizer = UITapGestureRecognizer(target: self, action: #selector(CameraViewController.snap(_:)))
         cameraView.addGestureRecognizer(recognizer)
         updateAuthorizationStatus()
     }

--- a/Moody/Moody/ConfigurableCell.swift
+++ b/Moody/Moody/ConfigurableCell.swift
@@ -8,6 +8,6 @@
 
 
 protocol ConfigurableCell {
-    typealias DataSource
+    associatedtype DataSource
     func configureForObject(object: DataSource)
 }

--- a/Moody/Moody/DataProvider.swift
+++ b/Moody/Moody/DataProvider.swift
@@ -10,14 +10,14 @@ import UIKit
 
 
 protocol DataProvider: class {
-    typealias Object
+    associatedtype Object
     func objectAtIndexPath(indexPath: NSIndexPath) -> Object
     func numberOfItemsInSection(section: Int) -> Int
 }
 
 
 protocol DataProviderDelegate: class {
-    typealias Object
+    associatedtype Object
     func dataProviderDidUpdate(updates: [DataProviderUpdate<Object>]?)
 }
 

--- a/Moody/Moody/DataSource.swift
+++ b/Moody/Moody/DataSource.swift
@@ -8,7 +8,7 @@
 
 
 protocol DataSourceDelegate: class {
-    typealias Object
+    associatedtype Object
     func cellIdentifierForObject(object: Object) -> String
 }
 

--- a/Moody/Moody/SegueHandlerType.swift
+++ b/Moody/Moody/SegueHandlerType.swift
@@ -10,7 +10,7 @@ import UIKit
 
 
 public protocol SegueHandlerType {
-     typealias SegueIdentifier: RawRepresentable
+     associatedtype SegueIdentifier: RawRepresentable
 }
 
 

--- a/Moody/MoodySync/ChangeProcessor.swift
+++ b/Moody/MoodySync/ChangeProcessor.swift
@@ -82,7 +82,7 @@ protocol ChangeProcessorContextType: class {
 /// The contract is that the implementation is such that objects no longer match the `predicateForLocallyTrackedElements` once they're actually complete.
 protocol ElementChangeProcessorType: ChangeProcessorType {
 
-    typealias Element: ManagedObject, ManagedObjectType
+    associatedtype Element: ManagedObject, ManagedObjectType
 
     /// Used to track if elements are already in progress.
     var elementsInProgress: InProgressTracker<Element> {get}

--- a/Moody/lib/DominantColor/DominantColor/Shared/ColorDifference.swift
+++ b/Moody/lib/DominantColor/DominantColor/Shared/ColorDifference.swift
@@ -23,7 +23,6 @@ private func C(a: Float, _ b: Float) -> Float {
     return sqrt(pow(a, 2) + pow(b, 2))
 }
 
-// TODO: How to fix? Curried function declaration syntax will be removed in a future version of Swift; use a single parameter list
 // From http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE94.html
 func CIE94SquaredColorDifference(
     kL: Float = 1,
@@ -51,7 +50,6 @@ func CIE94SquaredColorDifference(
     }
 }
 
-// TODO: How to fix? Curried function declaration syntax will be removed in a future version of Swift; use a single parameter list
 // From http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE2000.html
 func CIE2000SquaredColorDifference(
     kL: Float = 1,

--- a/Moody/lib/DominantColor/DominantColor/Shared/ColorDifference.swift
+++ b/Moody/lib/DominantColor/DominantColor/Shared/ColorDifference.swift
@@ -23,103 +23,110 @@ private func C(a: Float, _ b: Float) -> Float {
     return sqrt(pow(a, 2) + pow(b, 2))
 }
 
+// TODO: How to fix? Curried function declaration syntax will be removed in a future version of Swift; use a single parameter list
 // From http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE94.html
 func CIE94SquaredColorDifference(
-        kL: Float = 1,
-        kC: Float = 1,
-        kH: Float = 1,
-        K1: Float = 0.045,
-        K2: Float = 0.015
-    )(lab1:LABPixel, lab2:LABPixel) -> Float {
+    kL: Float = 1,
+    kC: Float = 1,
+    kH: Float = 1,
+    K1: Float = 0.045,
+    K2: Float = 0.015) -> (LABPixel, LABPixel) -> Float {
 
-    let (L1, a1, b1) = lab1.unpack()
-    let (L2, a2, b2) = lab2.unpack()
-    let ΔL = L1 - L2
-
-    let (C1, C2) = (C(a1, b1), C(a2, b2))
-    let ΔC = C1 - C2
-
-    let ΔH = sqrt(pow(a1 - a2, 2) + pow(b1 - b2, 2) - pow(ΔC, 2))
-
-    let Sl: Float = 1
-    let Sc = 1 + K1 * C1
-    let Sh = 1 + K2 * C1
-
-    return pow(ΔL / (kL * Sl), 2) + pow(ΔC / (kC * Sc), 2) + pow(ΔH / (kH * Sh), 2)
+    return {(lab1:LABPixel, lab2:LABPixel) -> Float in
+        
+        let (L1, a1, b1) = lab1.unpack()
+        let (L2, a2, b2) = lab2.unpack()
+        let ΔL = L1 - L2
+        
+        let (C1, C2) = (C(a1, b1), C(a2, b2))
+        let ΔC = C1 - C2
+        
+        let ΔH = sqrt(pow(a1 - a2, 2) + pow(b1 - b2, 2) - pow(ΔC, 2))
+        
+        let Sl: Float = 1
+        let Sc = 1 + K1 * C1
+        let Sh = 1 + K2 * C1
+        
+        return pow(ΔL / (kL * Sl), 2) + pow(ΔC / (kC * Sc), 2) + pow(ΔH / (kH * Sh), 2)
+    }
 }
 
+// TODO: How to fix? Curried function declaration syntax will be removed in a future version of Swift; use a single parameter list
 // From http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE2000.html
 func CIE2000SquaredColorDifference(
-        kL: Float = 1,
-        kC: Float = 1,
-        kH: Float = 1
-    )(lab1:LABPixel, lab2:LABPixel) -> Float {
-
-    let (L1, a1, b1) = lab1.unpack()
-    let (L2, a2, b2) = lab2.unpack()
-
-    let ΔLp = L2 - L1
-    let Lbp = (L1 + L2) / 2
-
-    let (C1, C2) = (C(a1, b1), C(a2, b2))
-    let Cb = (C1 + C2) / 2
-
-    let G = (1 - sqrt(pow(Cb, 7) / (pow(Cb, 7) + pow(25, 7)))) / 2
-    let ap: Float -> Float = { a in
-        return a * (1 + G)
-    }
-    let (a1p, a2p) = (ap(a1), ap(a2))
-
-    let (C1p, C2p) = (C(a1p, b1), C(a2p, b2))
-    let ΔCp = C2p - C1p
-    let Cbp = (C1p + C2p) / 2
-
-    let hp: (Float, Float) -> Float = { ap, b in
-        if ap == 0 && b == 0 { return 0 }
-        let θ = GLKMathRadiansToDegrees(atan2(b, ap))
-        return fmod(θ < 0 ? (θ + 360) : θ, 360)
-    }
-    let (h1p, h2p) = (hp(a1p, b1), hp(a2p, b2))
-    let Δhabs = abs(h1p - h2p)
-    let Δhp: Float = {
-        if (C1p == 0 || C2p == 0) {
-            return 0
-        } else if Δhabs <= 180 {
-            return h2p - h1p
-        } else if h2p <= h1p {
-            return h2p - h1p + 360
-        } else {
-            return h2p - h1p - 360
+    kL: Float = 1,
+    kC: Float = 1,
+    kH: Float = 1
+    ) -> (LABPixel, LABPixel) -> Float {
+    
+    return {(lab1:LABPixel, lab2:LABPixel) -> Float in
+        
+        let (L1, a1, b1) = lab1.unpack()
+        let (L2, a2, b2) = lab2.unpack()
+        
+        let ΔLp = L2 - L1
+        let Lbp = (L1 + L2) / 2
+        
+        let (C1, C2) = (C(a1, b1), C(a2, b2))
+        let Cb = (C1 + C2) / 2
+        
+        let G = (1 - sqrt(pow(Cb, 7) / (pow(Cb, 7) + pow(25, 7)))) / 2
+        let ap: Float -> Float = { a in
+            return a * (1 + G)
         }
-    }()
-
-    let ΔHp = 2 * sqrt(C1p * C2p) * sin(GLKMathDegreesToRadians(Δhp / 2))
-    let Hbp: Float = {
-        if (C1p == 0 || C2p == 0) {
-            return h1p + h2p
-        } else if Δhabs > 180 {
-            return (h1p + h2p + 360) / 2
-        } else {
-            return (h1p + h2p) / 2
+        let (a1p, a2p) = (ap(a1), ap(a2))
+        
+        let (C1p, C2p) = (C(a1p, b1), C(a2p, b2))
+        let ΔCp = C2p - C1p
+        let Cbp = (C1p + C2p) / 2
+        
+        let hp: (Float, Float) -> Float = { ap, b in
+            if ap == 0 && b == 0 { return 0 }
+            let θ = GLKMathRadiansToDegrees(atan2(b, ap))
+            return fmod(θ < 0 ? (θ + 360) : θ, 360)
         }
-    }()
-
-    var T: Float = 1
-    T -= 0.17 * cos(GLKMathDegreesToRadians(Hbp - 30))
-    T += 0.24 * cos(GLKMathDegreesToRadians(2 * Hbp))
-    T += 0.32 * cos(GLKMathDegreesToRadians(3 * Hbp + 6))
-    T -= 0.20 * cos(GLKMathDegreesToRadians(4 * Hbp - 63))
-
-    let Sl = 1 + (0.015 * pow(Lbp - 50, 2)) / sqrt(20 + pow(Lbp - 50, 2))
-    let Sc = 1 + 0.045 * Cbp
-    let Sh = 1 + 0.015 * Cbp * T
-
-    let Δθ = 30 * exp(-pow((Hbp - 275) / 25, 2))
-    let Rc = 2 * sqrt(pow(Cbp, 7) / (pow(Cbp, 7) + pow(25, 7)))
-    let Rt = -Rc * sin(GLKMathDegreesToRadians(2 * Δθ))
-
-    let Lterm = ΔLp / (kL * Sl)
-    let Cterm = ΔCp / (kC * Sc)
-    let Hterm = ΔHp / (kH * Sh)
-    return pow(Lterm, 2) + pow(Cterm, 2) + pow(Hterm, 2) + Rt * Cterm * Hterm
+        let (h1p, h2p) = (hp(a1p, b1), hp(a2p, b2))
+        let Δhabs = abs(h1p - h2p)
+        let Δhp: Float = {
+            if (C1p == 0 || C2p == 0) {
+                return 0
+            } else if Δhabs <= 180 {
+                return h2p - h1p
+            } else if h2p <= h1p {
+                return h2p - h1p + 360
+            } else {
+                return h2p - h1p - 360
+            }
+        }()
+        
+        let ΔHp = 2 * sqrt(C1p * C2p) * sin(GLKMathDegreesToRadians(Δhp / 2))
+        let Hbp: Float = {
+            if (C1p == 0 || C2p == 0) {
+                return h1p + h2p
+            } else if Δhabs > 180 {
+                return (h1p + h2p + 360) / 2
+            } else {
+                return (h1p + h2p) / 2
+            }
+        }()
+        
+        var T: Float = 1
+        T -= 0.17 * cos(GLKMathDegreesToRadians(Hbp - 30))
+        T += 0.24 * cos(GLKMathDegreesToRadians(2 * Hbp))
+        T += 0.32 * cos(GLKMathDegreesToRadians(3 * Hbp + 6))
+        T -= 0.20 * cos(GLKMathDegreesToRadians(4 * Hbp - 63))
+        
+        let Sl = 1 + (0.015 * pow(Lbp - 50, 2)) / sqrt(20 + pow(Lbp - 50, 2))
+        let Sc = 1 + 0.045 * Cbp
+        let Sh = 1 + 0.015 * Cbp * T
+        
+        let Δθ = 30 * exp(-pow((Hbp - 275) / 25, 2))
+        let Rc = 2 * sqrt(pow(Cbp, 7) / (pow(Cbp, 7) + pow(25, 7)))
+        let Rt = -Rc * sin(GLKMathDegreesToRadians(2 * Δθ))
+        
+        let Lterm = ΔLp / (kL * Sl)
+        let Cterm = ΔCp / (kC * Sc)
+        let Hterm = ΔHp / (kH * Sh)
+        return pow(Lterm, 2) + pow(Cterm, 2) + pow(Hterm, 2) + Rt * Cterm * Hterm
+    }
 }

--- a/Moody/lib/DominantColor/DominantColor/Shared/DominantColors.swift
+++ b/Moody/lib/DominantColor/DominantColor/Shared/DominantColors.swift
@@ -56,7 +56,7 @@ extension CGImage {
         }
 
         var clusterGenerator = clusters.generate()
-        return anyGenerator { () -> CGColor? in
+        return AnyGenerator { () -> CGColor? in
             return clusterGenerator.next().flatMap {
                 let lab = $0.centroid
                 let adjustedLAB = options.deemphasizeBlacks ? lab.deemphasizeBlacks : lab

--- a/Moody/lib/DominantColor/DominantColor/Shared/KMeans.swift
+++ b/Moody/lib/DominantColor/DominantColor/Shared/KMeans.swift
@@ -57,7 +57,7 @@ func kmeans<T: ClusteredType>(
                 error += 1
                 memberships[i] = clusterIndex
             }
-            newClusterSizes[clusterIndex]++
+            newClusterSizes[clusterIndex] += 1
             newCentroids[clusterIndex] = newCentroids[clusterIndex] + point
         }
         for i in 0..<k {

--- a/Moody/lib/DominantColor/DominantColor/Shared/PlatformExtensions.swift
+++ b/Moody/lib/DominantColor/DominantColor/Shared/PlatformExtensions.swift
@@ -33,7 +33,7 @@ public extension UIImage {
     public func dominantColors(options: DominantColorOptions = .Default) -> AnyGenerator<UIColor> {
         guard let cgImage = CGImage else { fatalError("Can't convert to CGImage") }
         let colors = cgImage.dominantColors(options)
-        return anyGenerator { () -> UIColor? in
+        return AnyGenerator { () -> UIColor? in
             return colors.next().flatMap { UIColor(CGColor: $0) }
         }
     }

--- a/SharedCode/KeyCodable.swift
+++ b/SharedCode/KeyCodable.swift
@@ -10,7 +10,7 @@ import CoreData
 
 
 public protocol KeyCodable {
-    typealias Keys: RawRepresentable
+    associatedtype Keys: RawRepresentable
 }
 
 extension KeyCodable where Self: ManagedObject, Keys.RawValue == String {

--- a/SharedCode/NSManagedObjectContext+Observers.swift
+++ b/SharedCode/NSManagedObjectContext+Observers.swift
@@ -41,10 +41,10 @@ public struct ContextDidSaveNotification {
 
     private func generatorForKey(key: String) -> AnyGenerator<ManagedObject> {
         guard let set = notification.userInfo?[key] as? NSSet else {
-            return anyGenerator { nil }
+            return AnyGenerator { nil }
         }
         let innerGenerator = set.generate()
-        return anyGenerator { return innerGenerator.next() as? ManagedObject }
+        return AnyGenerator { return innerGenerator.next() as? ManagedObject }
     }
 
 }


### PR DESCRIPTION
Fixed warnings when building in Xcode 7.3. Updated code based on suggestions from Xcode. Handled warning "Curried function declaration syntax will be removed in a future version of Swift; use a single parameter list."
