### PR TITLE
Avoid duplicating keys in will/did method calls.

### DIFF
--- a/SharedCode/KeyCodable.swift
+++ b/SharedCode/KeyCodable.swift
@@ -22,6 +22,12 @@ extension KeyCodable where Self: ManagedObject, Keys.RawValue == String {
         didAccessValueForKey(key.rawValue)
     }
 
+    public func accessingValueForKey(key: Keys, @noescape block: () -> ()) {
+        willAccessValueForKey(key)
+        block()
+        didAccessValueForKey(key)
+    }
+
     public func willChangeValueForKey(key: Keys) {
         (self as ManagedObject).willChangeValueForKey(key.rawValue)
     }
@@ -40,6 +46,12 @@ extension KeyCodable where Self: ManagedObject, Keys.RawValue == String {
 
     public func changedValueForKey(key: Keys) -> AnyObject? {
         return changedValues()[key.rawValue]
+    }
+
+    public func changingValueForKey(key: Keys, @noescape block: () -> ()) {
+        willChangeValueForKey(key)
+        block()
+        didChangeValueForKey(key)
     }
 
     public func committedValueForKey(key: Keys) -> AnyObject? {


### PR DESCRIPTION
Add `accessingValueForKey()` that takes a key and a block and wraps the block in `willAccessValueForKey()`/`didAccessValueForKey()`; same for `willChangeValueForKey()`/`didChangeValueForKey()`.

This allows writing:

    var foo {
        return accessingValueForKey(Keys.Foo) { primitiveFoo }
    }