### PR TITLE
Fixes update case

### DIFF
--- a/Moody/Moody/CollectionViewDataSource.swift
+++ b/Moody/Moody/CollectionViewDataSource.swift
@@ -105,7 +105,7 @@ class CollectionViewDataSource<Delegate: CollectionViewDataSourceDelegate>: NSOb
             guard let indexPath = newIndexPath else { fatalError("Index path should be not nil") }
             updates.append(.insert(indexPath))
         case .update:
-            guard let indexPath = indexPath else { fatalError("Index path should be not nil") }
+            guard let indexPath = newIndexPath else { fatalError("Index path should be not nil") }
             let object = objectAtIndexPath(indexPath)
             updates.append(.update(indexPath, object))
         case .move:


### PR DESCRIPTION
When update is mixed with deletion it sometimes refers to index paths out of bounds. Using newIndexPath fixes problem