### PR TITLE
Fix Swift 4.1 compiler issue

### DIFF
--- a/SharedCode/Utilities.swift
+++ b/SharedCode/Utilities.swift
@@ -42,7 +42,7 @@ extension Sequence {
 }
 
 
-extension Sequence where Iterator.Element: AnyObject {
+extension Sequence where Element: AnyObject {
     public func containsObjectIdentical(to object: AnyObject) -> Bool {
         return contains { $0 === object }
     }


### PR DESCRIPTION
This code doesn't compile anymore with Swift 4.1 beta. Not sure if this is a compiler regression or if it's expected.